### PR TITLE
Remove shoulder round replacement, consolidate to double gyp

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -70,30 +70,6 @@ const replaceChains = (terms) => {
 		.forEach(term('THREE_CHAIN_R'))
 }
 
-const replaceShoulderRounds = (terms) => {
-	if (!terms.has('RSR')) return
-
-	// Replacing gypsy is a little trickier since in Caller's Box
-	// the figure is notated, e.g.,
-	//     `<a href="...">gypsy</a> right`
-	// and we want to replace it with
-	//     `<a href="...">right shoulder round</a>`
-
-	document.querySelectorAll('a[href$="#gypsy"]').forEach(element => {
-		// We need the next node (should be a text node starting with "right" or
-		// "left") for a couple purposes
-		const nextSibling = element.nextSibling
-		if (!nextSibling || !nextSibling.textContent) return
-		// Get the direction of the shoulder round by checking the next word
-		const direction = nextSibling.textContent.trim().split(' ')[0]
-		// Remove that word from the next node 
-		nextSibling.textContent = nextSibling.textContent.replace(direction, '')
-		// Replace the term
-		const term = direction === 'right' ? 'RSR' : 'LSR'
-		element.textContent = terms.get(term)
-	})
-}
-
 const replaceDoubleGyp = (terms) => {
 	if (!terms.has('DOUBLE_TRADE')) return
 	
@@ -169,7 +145,6 @@ const init = async () => {
 		log("Replacing terms")
 
 		const termMaps = []
-		if (options.useRSR) termMaps.push(RSR_TERMS)
 		if (options.useRSR) termMaps.push(HALF_GYP_TERMS)
 		if (options.roleTerms === 'birds') termMaps.push(ROLE_TERMS_BIRDS)
 		if (options.roleTerms === 'lf') termMaps.push(ROLE_TERMS_LF)
@@ -178,7 +153,6 @@ const init = async () => {
 
 		replaceRoles(terms)
 		replaceChains(terms)
-		replaceShoulderRounds(terms)
 		replaceDoubleGyp(terms)
 		replaceMicroNotationChoreo(terms)
 		replaceMicroNotationFormation(terms)

--- a/extension/maps.js
+++ b/extension/maps.js
@@ -1,8 +1,3 @@
-const RSR_TERMS = new Map([
-	['RSR', 'right shoulder round'],
-	['LSR', 'left shoulder round'],
-])
-
 const HALF_GYP_TERMS = new Map([
 	// Double gyp always seems to show up as "Corner trade 4 (quick trades)"
 	// so this should be a reasonable substitution

--- a/extension/options.html
+++ b/extension/options.html
@@ -44,8 +44,8 @@
 				</section>
 
 				<section class="form-row">
-					<label title=”Replace “double gyp” with “quick trades””>
-						<input type=”checkbox” name=”useRSR”> Replace “double gyp” with “quick trades”
+					<label title="Replace “double gyp” with “quick trades”">
+						<input type="checkbox" name="useRSR"> Replace “double gyp” with “quick trades”
 					</label>
 				</section>
 

--- a/extension/options.html
+++ b/extension/options.html
@@ -44,8 +44,8 @@
 				</section>
 
 				<section class="form-row">
-					<label title="Replace “gypsy” with “right shoulder round”">
-						<input type="checkbox" name="useRSR"> Use "right shoulder round"
+					<label title=”Replace “double gyp” with “quick trades””>
+						<input type=”checkbox” name=”useRSR”> Replace “double gyp” with “quick trades”
 					</label>
 				</section>
 


### PR DESCRIPTION
## Summary
This PR removes the shoulder round (RSR/LSR) replacement functionality and consolidates the `useRSR` option to exclusively handle double gyp to quick trades replacement.

## Key Changes
- Removed `replaceShoulderRounds()` function that replaced gypsy with right/left shoulder round
- Removed `RSR_TERMS` map definition containing shoulder round terminology
- Removed `RSR_TERMS` from the term maps initialization in `init()`
- Updated the `useRSR` checkbox label and title in options.html to reflect its new purpose: replacing "double gyp" with "quick trades" instead of shoulder round replacement
- Kept `HALF_GYP_TERMS` map which handles the double gyp replacement

## Implementation Details
The `useRSR` option now serves a single, focused purpose of enabling double gyp to quick trades replacement via the `HALF_GYP_TERMS` map. The shoulder round replacement logic has been completely removed, simplifying the codebase and reducing the scope of this configuration option.

https://claude.ai/code/session_01EXWra7EwMiuWfRmj9gdtEE