### PR TITLE
Add ESLint, test suite, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,24 +9,26 @@ dance choreography website with gender-neutral alternatives.
 ```
 extension/           # All extension source files (loaded directly, no build step)
   manifest.json      # MV3 manifest — defines content scripts, permissions, icons
-  maps.js            # Term mapping constants (loaded first as a content script)
-  main.js            # Core DOM manipulation logic (loaded second)
+  maps.js            # Term mapping constants (ES module, exports Map objects)
+  main.js            # Content script entry point (imports maps.js)
   options.html       # Settings popup / options page UI
   options.js         # Web Component for the settings form
   icons/             # Extension icons (48, 96, 128 px)
+eslint.config.mjs    # ESLint flat config
 ```
 
 There is no build system or bundler. The extension source lives in `extension/`
-and is loaded directly. `web-ext` is used for linting, running in Firefox, and
-packaging for distribution.
+and is loaded directly. Scripts use ES module syntax (`import`/`export`);
+content scripts are declared with `"type": "module"` in the manifest. `web-ext`
+is used for running in Firefox and packaging for distribution.
 
 ## How It Works
 
-1. `maps.js` defines `Map` constants for terminology substitutions (e.g.,
+1. `maps.js` exports `Map` constants for terminology substitutions (e.g.,
    `RSR_TERMS`, `ROLE_TERMS_BIRDS`, `ROLE_TERMS_LF`).
-2. `main.js` runs as a content script on matching Caller's Box dance pages. It
-   reads user preferences from `browser.storage.sync`, then performs DOM text
-   replacements using the term maps.
+2. `main.js` is the content script entry point. It imports the term maps from
+   `maps.js`, reads user preferences from `browser.storage.sync`, then performs
+   DOM text replacements.
 3. `options.js` defines a `<cb-options-form>` custom element that persists
    settings to `browser.storage.sync`. The options page doubles as the popup.
 
@@ -57,7 +59,9 @@ auto-reloads on file changes.
 ### Linting
 
 ```sh
-npm run lint
+npm run lint        # ESLint + web-ext lint (run both)
+npm run lint:js     # ESLint only
+npm run lint:ext    # web-ext lint only (manifest validation)
 ```
 
 ### Building for distribution
@@ -72,7 +76,7 @@ This creates a `.zip` in `web-ext-artifacts/`.
 
 - Tab indentation (see `.editorconfig`)
 - LF line endings
-- Vanilla JS (ES6+), no frameworks or transpilation
+- Vanilla JS (ES modules), no frameworks or transpilation
 - Cross-browser: uses `chrome`/`browser` API abstraction
 
 ### Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ dance choreography website with gender-neutral alternatives.
 extension/           # All extension source files (loaded directly, no build step)
   manifest.json      # MV3 manifest — defines content scripts, permissions, icons
   maps.js            # Term mapping constants (ES module, exports Map objects)
-  main.js            # Content script entry point (imports maps.js)
+  main.js            # Content script entry point (dynamically imports maps.js)
   options.html       # Settings popup / options page UI
   options.js         # Web Component for the settings form
   icons/             # Extension icons (48, 96, 128 px)
@@ -18,17 +18,18 @@ eslint.config.mjs    # ESLint flat config
 ```
 
 There is no build system or bundler. The extension source lives in `extension/`
-and is loaded directly. Scripts use ES module syntax (`import`/`export`);
-content scripts are declared with `"type": "module"` in the manifest. `web-ext`
-is used for running in Firefox and packaging for distribution.
+and is loaded directly. `maps.js` uses ES module `export` syntax; the content
+script (`main.js`) loads it via dynamic `import()` since browsers don't support
+static ES module imports in content scripts. `web-ext` is used for running in
+Firefox and packaging for distribution.
 
 ## How It Works
 
 1. `maps.js` exports `Map` constants for terminology substitutions (e.g.,
    `RSR_TERMS`, `ROLE_TERMS_BIRDS`, `ROLE_TERMS_LF`).
-2. `main.js` is the content script entry point. It imports the term maps from
-   `maps.js`, reads user preferences from `browser.storage.sync`, then performs
-   DOM text replacements.
+2. `main.js` is the content script entry point. It dynamically imports the term
+   maps from `maps.js`, reads user preferences from `browser.storage.sync`,
+   then performs DOM text replacements.
 3. `options.js` defines a `<cb-options-form>` custom element that persists
    settings to `browser.storage.sync`. The options page doubles as the popup.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,29 +8,33 @@ dance choreography website with gender-neutral alternatives.
 
 ```
 extension/           # All extension source files (loaded directly, no build step)
+  content-script.js  # Content script entry point (thin loader, dynamically imports main.js)
   manifest.json      # MV3 manifest — defines content scripts, permissions, icons
   maps.js            # Term mapping constants (ES module, exports Map objects)
-  main.js            # Content script entry point (dynamically imports maps.js)
+  main.js            # Core logic module (ES module, imports maps.js, exports functions)
   options.html       # Settings popup / options page UI
   options.js         # Web Component for the settings form
   icons/             # Extension icons (48, 96, 128 px)
+tests/               # Automated tests (node:test + jsdom)
 eslint.config.mjs    # ESLint flat config
 ```
 
 There is no build system or bundler. The extension source lives in `extension/`
-and is loaded directly. `maps.js` uses ES module `export` syntax; the content
-script (`main.js`) loads it via dynamic `import()` since browsers don't support
-static ES module imports in content scripts. `web-ext` is used for running in
-Firefox and packaging for distribution.
+and is loaded directly. `content-script.js` is a thin classic-script entry
+point that dynamically imports `main.js` as an ES module (browsers don't
+support static ES module imports in content scripts). `main.js` then uses
+standard static `import`/`export` with `maps.js`. `web-ext` is used for
+running in Firefox and packaging for distribution.
 
 ## How It Works
 
 1. `maps.js` exports `Map` constants for terminology substitutions (e.g.,
    `RSR_TERMS`, `ROLE_TERMS_BIRDS`, `ROLE_TERMS_LF`).
-2. `main.js` is the content script entry point. It dynamically imports the term
-   maps from `maps.js`, reads user preferences from `browser.storage.sync`,
-   then performs DOM text replacements.
-3. `options.js` defines a `<cb-options-form>` custom element that persists
+2. `content-script.js` is the manifest-declared content script entry point. It
+   dynamically imports `main.js` as an ES module.
+3. `main.js` imports the term maps from `maps.js`, reads user preferences from
+   `browser.storage.sync`, then performs DOM text replacements.
+4. `options.js` defines a `<cb-options-form>` custom element that persists
    settings to `browser.storage.sync`. The options page doubles as the popup.
 
 ## Development
@@ -82,6 +86,15 @@ This creates a `.zip` in `web-ext-artifacts/`.
 
 ### Testing
 
-No automated tests. Test manually by loading the extension and visiting a
-Caller's Box dance page such as:
+```sh
+npm test
+```
+
+Tests use Node.js built-in test runner (`node:test`) with jsdom for DOM
+simulation. They cover the term maps, all replacement functions, and manifest
+validation (including checks that content scripts don't use unsupported
+`"type": "module"` or static `import` syntax).
+
+Also test manually by loading the extension and visiting a Caller's Box dance
+page such as:
 https://www.ibiblio.org/contradance/thecallersbox/dance.php?id=7868

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,29 @@
+import globals from "globals"
+
+export default [
+	{
+		files: ["extension/**/*.js"],
+		languageOptions: {
+			ecmaVersion: "latest",
+			sourceType: "module",
+			globals: {
+				...globals.browser,
+				chrome: "readonly",
+				browser: "readonly",
+			},
+		},
+		rules: {
+			"no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+			"no-undef": "error",
+			"no-redeclare": "error",
+			eqeqeq: ["error", "always"],
+			"no-const-assign": "error",
+			"no-dupe-args": "error",
+			"no-dupe-keys": "error",
+			"no-duplicate-case": "error",
+			"no-unreachable": "error",
+			"no-var": "error",
+			"prefer-const": "error",
+		},
+	},
+]

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,4 +1,6 @@
 // Thin entry point for content scripts. Dynamically imports main.js as an
 // ES module (content scripts can't use static imports directly).
 const browser = globalThis.chrome ?? globalThis.browser
-import(browser.runtime.getURL('main.js'))
+import(browser.runtime.getURL('main.js')).catch(err =>
+	console.error(`[Caller's Box Configurator] Failed to load main.js: ${err.message}`)
+)

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,0 +1,4 @@
+// Thin entry point for content scripts. Dynamically imports main.js as an
+// ES module (content scripts can't use static imports directly).
+const browser = globalThis.chrome ?? globalThis.browser
+import(browser.runtime.getURL('main.js'))

--- a/extension/main.js
+++ b/extension/main.js
@@ -1,15 +1,8 @@
-import {
-	RSR_TERMS,
-	HALF_GYP_TERMS,
-	ROLE_TERMS_BIRDS,
-	ROLE_TERMS_LF,
-} from './maps.js'
+const browser = globalThis.chrome ?? globalThis.browser
 
 const log = (str) => console?.log(`[Caller's Box Configurator] ${str}`)
 
 log("Running")
-
-const browser = globalThis.chrome ?? globalThis.browser
 
 const getOptions = async () => {
 	const data = await browser.storage.sync.get([
@@ -129,6 +122,15 @@ const replaceMicroNotationFormation = (terms) => {
 
 // Instantiation:
 const init = async () => {
+	// Import term maps (dynamic import because content scripts can't use
+	// static ES module imports)
+	const {
+		RSR_TERMS,
+		HALF_GYP_TERMS,
+		ROLE_TERMS_BIRDS,
+		ROLE_TERMS_LF,
+	} = await import(browser.runtime.getURL('maps.js'))
+
 	// Get initial options
 	const options = await getOptions()
 

--- a/extension/main.js
+++ b/extension/main.js
@@ -1,5 +1,4 @@
 import {
-	RSR_TERMS,
 	HALF_GYP_TERMS,
 	ROLE_TERMS_BIRDS,
 	ROLE_TERMS_LF,
@@ -75,30 +74,6 @@ export const replaceChains = (terms) => {
 }
 
 export const replaceDoubleGyp = (terms) => {
-	if (!terms.has('RSR')) return
-
-	// Replacing gypsy is a little trickier since in Caller's Box
-	// the figure is notated, e.g.,
-	//     `<a href="...">gypsy</a> right`
-	// and we want to replace it with
-	//     `<a href="...">right shoulder round</a>`
-
-	document.querySelectorAll('a[href$="#gypsy"]').forEach(element => {
-		// We need the next node (should be a text node starting with "right" or
-		// "left") for a couple purposes
-		const nextSibling = element.nextSibling
-		if (!nextSibling || !nextSibling.textContent) return
-		// Get the direction of the shoulder round by checking the next word
-		const direction = nextSibling.textContent.trim().split(' ')[0]
-		// Remove that word from the next node
-		nextSibling.textContent = nextSibling.textContent.replace(direction, '')
-		// Replace the term
-		const term = direction === 'right' ? 'RSR' : 'LSR'
-		element.textContent = terms.get(term)
-	})
-}
-
-export const replaceDoubleGyp = (terms) => {
 	if (!terms.has('DOUBLE_TRADE')) return
 
 	const term = replaceTerm(terms)
@@ -153,7 +128,6 @@ export const replaceMicroNotationFormation = (terms) => {
 
 export const buildTerms = (options) => {
 	const termMaps = []
-	if (options.useRSR) termMaps.push(RSR_TERMS)
 	if (options.useRSR) termMaps.push(HALF_GYP_TERMS)
 	if (options.roleTerms === 'birds') termMaps.push(ROLE_TERMS_BIRDS)
 	if (options.roleTerms === 'lf') termMaps.push(ROLE_TERMS_LF)
@@ -166,7 +140,6 @@ export const replaceAll = (options) => {
 	const terms = buildTerms(options)
 	replaceRoles(terms)
 	replaceChains(terms)
-	replaceShoulderRounds(terms)
 	replaceDoubleGyp(terms)
 	replaceMicroNotationChoreo(terms)
 	replaceMicroNotationFormation(terms)

--- a/extension/main.js
+++ b/extension/main.js
@@ -1,5 +1,9 @@
-// This script relies on maps.js loading first
-// and populating the global namespace
+import {
+	RSR_TERMS,
+	HALF_GYP_TERMS,
+	ROLE_TERMS_BIRDS,
+	ROLE_TERMS_LF,
+} from './maps.js'
 
 const log = (str) => console?.log(`[Caller's Box Configurator] ${str}`)
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,7 +12,6 @@
 		{
 			"matches": ["*://*.ibiblio.org/contradance/thecallersbox/dance.php?id=*"],
 			"js": ["main.js"],
-			"type": "module",
 			"run_at": "document_end"
 		}
 	],
@@ -30,7 +29,7 @@
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "callersboxconfigurator@chromamine.com",
-			"strict_min_version": "128.0"
+			"strict_min_version": "109.0"
 		}
 	},
 	"permissions": ["storage"]

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,7 +11,7 @@
 	"content_scripts": [
 		{
 			"matches": ["*://*.ibiblio.org/contradance/thecallersbox/dance.php?id=*"],
-			"js": ["main.js"],
+			"js": ["content-script.js"],
 			"run_at": "document_end"
 		}
 	],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,7 +11,8 @@
 	"content_scripts": [
 		{
 			"matches": ["*://*.ibiblio.org/contradance/thecallersbox/dance.php?id=*"],
-			"js": ["maps.js", "main.js"],
+			"js": ["main.js"],
+			"type": "module",
 			"run_at": "document_end"
 		}
 	],
@@ -29,7 +30,7 @@
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "callersboxconfigurator@chromamine.com",
-			"strict_min_version": "109.0"
+			"strict_min_version": "128.0"
 		}
 	},
 	"permissions": ["storage"]

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -32,5 +32,11 @@
 			"strict_min_version": "109.0"
 		}
 	},
+	"web_accessible_resources": [
+		{
+			"resources": ["main.js", "maps.js"],
+			"matches": ["*://*.ibiblio.org/*"]
+		}
+	],
 	"permissions": ["storage"]
 }

--- a/extension/maps.js
+++ b/extension/maps.js
@@ -30,7 +30,7 @@ export const ROLE_TERMS_LF = new Map([
 	['GRAND_CHAIN_L', 'Leads grand chain'],
 	['OPEN_CHAIN_R', 'Follows open chain'],
 	['OPEN_CHAIN_L', 'Leads open chain'],
-	['THREE_CHAIN_R', 'Three follows chain'],
+	['THREE_CHAIN_R', 'Three Follows chain'],
 	// Single initials for micro-notation, such as in hey or waves descriptions
 	['MICRO_R', 'F'],
 	['MICRO_L', 'L'],

--- a/extension/maps.js
+++ b/extension/maps.js
@@ -1,10 +1,10 @@
-const HALF_GYP_TERMS = new Map([
+export const HALF_GYP_TERMS = new Map([
 	// Double gyp always seems to show up as "Corner trade 4 (quick trades)"
 	// so this should be a reasonable substitution
 	['DOUBLE_TRADE', 'quick trades'],
 ])
 
-const ROLE_TERMS_BIRDS = new Map([
+export const ROLE_TERMS_BIRDS = new Map([
 	['ROLE_R', 'Robins'],
 	['ROLE_L', 'Larks'],
 	['CHAIN_R', 'Robins chain'],
@@ -20,7 +20,7 @@ const ROLE_TERMS_BIRDS = new Map([
 	['MICRO_L', 'L'],
 ])
 
-const ROLE_TERMS_LF = new Map([
+export const ROLE_TERMS_LF = new Map([
 	['ROLE_R', 'Follows'],
 	['ROLE_L', 'Leads'],
 	['CHAIN_R', 'Follows chain'],

--- a/extension/options.html
+++ b/extension/options.html
@@ -60,6 +60,6 @@
 			</form>
 		</cb-options-form>
 	</div>
-	<script src="options.js"></script>
+	<script type="module" src="options.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,51 @@
 			"devDependencies": {
 				"eslint": "^8.57.1",
 				"globals": "^17.3.0",
+				"jsdom": "^28.1.0",
 				"web-ext": "^8.0.0"
 			}
+		},
+		"node_modules/@acemir/cssom": {
+			"version": "0.9.31",
+			"resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+			"integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+			"integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/css-calc": "^3.0.0",
+				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0",
+				"lru-cache": "^11.2.5"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+			"integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.1.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.2.6"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.29.0",
@@ -46,6 +89,151 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.0.1",
+				"@csstools/css-calc": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.0.27",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+			"integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0"
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@devicefarmer/adbkit": {
@@ -248,6 +436,24 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+			"integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@fluent/syntax": {
@@ -701,6 +907,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
+			}
+		},
 		"node_modules/bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1138,6 +1354,20 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/css-tree": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.12.2",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
 		"node_modules/css-what": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -1149,6 +1379,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cssstyle": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
+			"integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^4.1.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+				"css-tree": "^3.1.0",
+				"lru-cache": "^11.2.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/debounce": {
@@ -1188,6 +1448,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/deep-extend": {
 			"version": "0.6.0",
@@ -2065,6 +2332,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/htmlparser2": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -2083,6 +2363,20 @@
 				"domhandler": "^5.0.3",
 				"domutils": "^3.0.1",
 				"entities": "^4.4.0"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -2358,6 +2652,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-relative": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
@@ -2429,6 +2730,73 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "28.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+			"integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@acemir/cssom": "^0.9.31",
+				"@asamuzakjp/dom-selector": "^6.8.1",
+				"@bramus/specificity": "^2.4.2",
+				"@exodus/bytes": "^1.11.0",
+				"cssstyle": "^6.0.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"is-potential-custom-element-name": "^1.0.1",
+				"parse5": "^8.0.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.0",
+				"undici": "^7.21.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jsdom/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/jsdom/node_modules/parse5": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+			"integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/json-buffer": {
@@ -2623,6 +2991,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lru-cache": {
+			"version": "11.2.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -2636,6 +3014,13 @@
 			"integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/mdn-data": {
+			"version": "2.12.2",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
@@ -3343,6 +3728,19 @@
 				"node": ">=11.0.0"
 			}
 		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
 		"node_modules/semver": {
 			"version": "7.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -3414,6 +3812,16 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -3619,6 +4027,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3643,6 +4058,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tldts": {
+			"version": "7.0.23",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+			"integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.0.23"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.0.23",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+			"integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tmp": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -3651,6 +4086,32 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.14"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+			"integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/type-check": {
@@ -3685,6 +4146,16 @@
 			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/undici": {
+			"version": "7.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
 		},
 		"node_modules/undici-types": {
 			"version": "7.16.0",
@@ -3779,6 +4250,19 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/watchpack": {
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -3844,6 +4328,41 @@
 			"engines": {
 				"node": ">=18.0.0",
 				"npm": ">=8.0.0"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/when": {
@@ -4021,6 +4540,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/xml2js": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -4044,6 +4573,13 @@
 			"engines": {
 				"node": ">=4.0"
 			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
 			"name": "cb-configurator",
 			"version": "0.2.0",
 			"devDependencies": {
+				"eslint": "^8.57.1",
+				"globals": "^17.3.0",
 				"web-ext": "^8.0.0"
 			}
 		},
@@ -155,9 +157,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -200,6 +202,22 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -1573,6 +1591,22 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/eslint/node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1981,16 +2015,13 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"version": "17.3.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
+			"integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,51 +10,23 @@
 			"devDependencies": {
 				"eslint": "^8.57.1",
 				"globals": "^17.3.0",
-				"jsdom": "^28.1.0",
+				"jsdom": "^25.0.1",
 				"web-ext": "^8.0.0"
 			}
 		},
-		"node_modules/@acemir/cssom": {
-			"version": "0.9.31",
-			"resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-			"integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-			"integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/css-calc": "^3.0.0",
-				"@csstools/css-color-parser": "^4.0.1",
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0",
-				"lru-cache": "^11.2.5"
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
 			}
-		},
-		"node_modules/@asamuzakjp/dom-selector": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-			"integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@asamuzakjp/nwsapi": "^2.3.9",
-				"bidi-js": "^1.0.3",
-				"css-tree": "^3.1.0",
-				"is-potential-custom-element-name": "^1.0.1",
-				"lru-cache": "^11.2.6"
-			}
-		},
-		"node_modules/@asamuzakjp/nwsapi": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.29.0",
@@ -91,23 +63,10 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@bramus/specificity": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"css-tree": "^3.0.0"
-			},
-			"bin": {
-				"specificity": "bin/cli.js"
-			}
-		},
 		"node_modules/@csstools/color-helpers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-			"integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
 			"dev": true,
 			"funding": [
 				{
@@ -121,13 +80,13 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -141,17 +100,17 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-			"integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
 			"dev": true,
 			"funding": [
 				{
@@ -165,21 +124,21 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.1",
-				"@csstools/css-calc": "^3.0.0"
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0"
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -193,33 +152,16 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^4.0.0"
+				"@csstools/css-tokenizer": "^3.0.4"
 			}
 		},
-		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.0.27",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
-			"integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0"
-		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
 			"dev": true,
 			"funding": [
 				{
@@ -233,7 +175,7 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@devicefarmer/adbkit": {
@@ -436,24 +378,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/@exodus/bytes": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
-			"integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"@noble/hashes": "^1.8.0 || ^2.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@noble/hashes": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@fluent/syntax": {
@@ -879,6 +803,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/atomic-sleep": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -906,16 +837,6 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/bidi-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"require-from-string": "^2.0.2"
-			}
 		},
 		"node_modules/bluebird": {
 			"version": "3.7.2",
@@ -1022,6 +943,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/callsites": {
@@ -1235,6 +1170,19 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "9.5.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -1354,20 +1302,6 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
-		"node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
-			},
-			"engines": {
-				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-			}
-		},
 		"node_modules/css-what": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -1382,33 +1316,38 @@
 			}
 		},
 		"node_modules/cssstyle": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
-			"integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/css-color": "^4.1.2",
-				"@csstools/css-syntax-patches-for-csstree": "^1.0.26",
-				"css-tree": "^3.1.0",
-				"lru-cache": "^11.2.5"
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=18"
 			}
 		},
+		"node_modules/cssstyle/node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/data-urls": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"whatwg-mimetype": "^5.0.0",
-				"whatwg-url": "^16.0.0"
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/debounce": {
@@ -1539,6 +1478,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1640,6 +1589,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/emoji-regex": {
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -1668,6 +1632,55 @@
 			"license": "MIT",
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/es6-error": {
@@ -2116,6 +2129,23 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/form-data": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/fs-extra": {
 			"version": "11.3.3",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
@@ -2137,6 +2167,16 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/fx-runner": {
 			"version": "1.4.0",
@@ -2211,6 +2251,45 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/glob": {
@@ -2294,6 +2373,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2332,17 +2424,59 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/html-encoding-sniffer": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@exodus/bytes": "^1.6.0"
+				"has-symbols": "^1.0.3"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/htmlparser2": {
@@ -2391,6 +2525,19 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ignore": {
@@ -2733,70 +2880,44 @@
 			}
 		},
 		"node_modules/jsdom": {
-			"version": "28.1.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
-			"integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+			"version": "25.0.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+			"integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@acemir/cssom": "^0.9.31",
-				"@asamuzakjp/dom-selector": "^6.8.1",
-				"@bramus/specificity": "^2.4.2",
-				"@exodus/bytes": "^1.11.0",
-				"cssstyle": "^6.0.1",
-				"data-urls": "^7.0.0",
-				"decimal.js": "^10.6.0",
-				"html-encoding-sniffer": "^6.0.0",
+				"cssstyle": "^4.1.0",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.4.3",
+				"form-data": "^4.0.0",
+				"html-encoding-sniffer": "^4.0.0",
 				"http-proxy-agent": "^7.0.2",
-				"https-proxy-agent": "^7.0.6",
+				"https-proxy-agent": "^7.0.5",
 				"is-potential-custom-element-name": "^1.0.1",
-				"parse5": "^8.0.0",
+				"nwsapi": "^2.2.12",
+				"parse5": "^7.1.2",
+				"rrweb-cssom": "^0.7.1",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^6.0.0",
-				"undici": "^7.21.0",
+				"tough-cookie": "^5.0.0",
 				"w3c-xmlserializer": "^5.0.0",
-				"webidl-conversions": "^8.0.1",
-				"whatwg-mimetype": "^5.0.0",
-				"whatwg-url": "^16.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0",
+				"ws": "^8.18.0",
 				"xml-name-validator": "^5.0.0"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"canvas": "^3.0.0"
+				"canvas": "^2.11.2"
 			},
 			"peerDependenciesMeta": {
 				"canvas": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/jsdom/node_modules/entities": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/jsdom/node_modules/parse5": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-			"integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"entities": "^6.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/json-buffer": {
@@ -2992,14 +3113,11 @@
 			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.2.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
-			}
+			"license": "ISC"
 		},
 		"node_modules/make-error": {
 			"version": "1.3.6",
@@ -3015,12 +3133,38 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
-		"node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
 			"dev": true,
-			"license": "CC0-1.0"
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
@@ -3115,6 +3259,13 @@
 			"funding": {
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
+		},
+		"node_modules/nwsapi": {
+			"version": "2.2.23",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+			"integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/on-exit-leak-free": {
 			"version": "2.1.2",
@@ -3664,6 +3815,13 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+			"integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/run-applescript": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -3717,6 +3875,13 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/sax": {
 			"version": "1.4.4",
@@ -3812,16 +3977,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/source-map-js": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -4059,22 +4214,22 @@
 			"license": "MIT"
 		},
 		"node_modules/tldts": {
-			"version": "7.0.23",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
-			"integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.0.23"
+				"tldts-core": "^6.1.86"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.0.23",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
-			"integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4089,29 +4244,29 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-			"integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"tldts": "^7.0.5"
+				"tldts": "^6.1.32"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/tr46": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=18"
 			}
 		},
 		"node_modules/type-check": {
@@ -4146,16 +4301,6 @@
 			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/undici": {
-			"version": "7.22.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.18.1"
-			}
 		},
 		"node_modules/undici-types": {
 			"version": "7.16.0",
@@ -4331,38 +4476,51 @@
 			}
 		},
 		"node_modules/webidl-conversions": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">=20"
+				"node": ">=12"
 			}
 		},
-		"node_modules/whatwg-mimetype": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/whatwg-url": {
-			"version": "16.0.1",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@exodus/bytes": "^1.11.0",
-				"tr46": "^6.0.0",
-				"webidl-conversions": "^8.0.1"
+				"iconv-lite": "0.6.3"
 			},
 			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/when": {
@@ -4494,6 +4652,28 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/ws": {
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/wsl-utils": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
 		"build": "web-ext build -s extension/",
 		"lint": "eslint extension/ && web-ext lint -s extension/",
 		"lint:js": "eslint extension/",
-		"lint:ext": "web-ext lint -s extension/"
+		"lint:ext": "web-ext lint -s extension/",
+		"test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test 'tests/**/*.test.mjs'"
 	},
 	"devDependencies": {
 		"eslint": "^8.57.1",
 		"globals": "^17.3.0",
+		"jsdom": "^28.1.0",
 		"web-ext": "^8.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"eslint": "^8.57.1",
 		"globals": "^17.3.0",
-		"jsdom": "^28.1.0",
+		"jsdom": "^25.0.1",
 		"web-ext": "^8.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,13 @@
 	"scripts": {
 		"start": "web-ext run -s extension/",
 		"build": "web-ext build -s extension/",
-		"lint": "web-ext lint -s extension/"
+		"lint": "eslint extension/ && web-ext lint -s extension/",
+		"lint:js": "eslint extension/",
+		"lint:ext": "web-ext lint -s extension/"
 	},
 	"devDependencies": {
+		"eslint": "^8.57.1",
+		"globals": "^17.3.0",
 		"web-ext": "^8.0.0"
 	}
 }

--- a/tests/main.test.mjs
+++ b/tests/main.test.mjs
@@ -1,0 +1,386 @@
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { setupDOM } from './setup.mjs'
+import {
+	replaceRoles,
+	replaceChains,
+	replaceShoulderRounds,
+	replaceDoubleGyp,
+	replaceMicroNotationChoreo,
+	replaceMicroNotationFormation,
+	buildTerms,
+	replaceAll,
+	getDescendentTextNodes,
+	getFormationCell,
+} from '../extension/main.js'
+import {
+	RSR_TERMS,
+	HALF_GYP_TERMS,
+	ROLE_TERMS_BIRDS,
+	ROLE_TERMS_LF,
+} from '../extension/maps.js'
+
+// Helper: merge multiple term maps into one (same logic as buildTerms)
+const mergeTerms = (...maps) =>
+	new Map([...maps.map(m => [...m])].flat())
+
+// ── buildTerms ──────────────────────────────────────────────────────────
+
+describe('buildTerms', () => {
+	it('includes RSR and half-gyp terms when useRSR is true', () => {
+		const terms = buildTerms({ useRSR: true, roleTerms: 'mw' })
+		assert.equal(terms.get('RSR'), 'right shoulder round')
+		assert.equal(terms.get('DOUBLE_TRADE'), 'quick trades')
+	})
+
+	it('excludes RSR terms when useRSR is false', () => {
+		const terms = buildTerms({ useRSR: false, roleTerms: 'mw' })
+		assert.equal(terms.has('RSR'), false)
+		assert.equal(terms.has('DOUBLE_TRADE'), false)
+	})
+
+	it('includes birds role terms when roleTerms is "birds"', () => {
+		const terms = buildTerms({ useRSR: false, roleTerms: 'birds' })
+		assert.equal(terms.get('ROLE_R'), 'Robins')
+		assert.equal(terms.get('ROLE_L'), 'Larks')
+	})
+
+	it('includes lead/follow role terms when roleTerms is "lf"', () => {
+		const terms = buildTerms({ useRSR: false, roleTerms: 'lf' })
+		assert.equal(terms.get('ROLE_R'), 'Follows')
+		assert.equal(terms.get('ROLE_L'), 'Leads')
+	})
+
+	it('includes no role terms when roleTerms is "mw"', () => {
+		const terms = buildTerms({ useRSR: false, roleTerms: 'mw' })
+		assert.equal(terms.has('ROLE_R'), false)
+	})
+})
+
+// ── replaceRoles ────────────────────────────────────────────────────────
+
+describe('replaceRoles', () => {
+	const terms = mergeTerms(ROLE_TERMS_BIRDS)
+
+	beforeEach(() => {
+		setupDOM(`<!DOCTYPE html><html><body>
+			<a href="/glossary#men">men</a>
+			<a href="/glossary#women">women</a>
+		</body></html>`)
+	})
+
+	it('replaces men/women links with Larks/Robins', () => {
+		replaceRoles(terms)
+		const men = document.querySelector('a[href$="#men"]')
+		const women = document.querySelector('a[href$="#women"]')
+		assert.equal(men.textContent, 'Larks')
+		assert.equal(women.textContent, 'Robins')
+	})
+
+	it('does nothing when terms has no ROLE_R key', () => {
+		replaceRoles(new Map())
+		const men = document.querySelector('a[href$="#men"]')
+		assert.equal(men.textContent, 'men')
+	})
+})
+
+// ── replaceChains ───────────────────────────────────────────────────────
+
+describe('replaceChains', () => {
+	const terms = mergeTerms(ROLE_TERMS_BIRDS)
+
+	beforeEach(() => {
+		setupDOM(`<!DOCTYPE html><html><body>
+			<a href="/glossary#ladies-chain">ladies chain</a>
+			<a href="/glossary#gents-chain">gents chain</a>
+			<a href="/glossary#right-hand-ladies-chain">right-hand ladies chain</a>
+			<a href="/glossary#grand-ladies-chain">grand ladies chain</a>
+			<a href="/glossary#grand-gents-chain">grand gents chain</a>
+			<a href="/glossary#open-ladies-chain">open ladies chain</a>
+			<a href="/glossary#open-gents-chain">open gents chain</a>
+			<a href="/glossary#three-ladies-chain">three ladies chain</a>
+		</body></html>`)
+	})
+
+	it('replaces all chain variants', () => {
+		replaceChains(terms)
+		assert.equal(
+			document.querySelector('a[href$="#ladies-chain"]').textContent,
+			'Robins chain'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#gents-chain"]').textContent,
+			'Larks chain'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#right-hand-ladies-chain"]').textContent,
+			'right-hand chain'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#grand-ladies-chain"]').textContent,
+			'Robins grand chain'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#grand-gents-chain"]').textContent,
+			'Larks grand chain'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#open-ladies-chain"]').textContent,
+			'Robins open chain'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#open-gents-chain"]').textContent,
+			'Larks open chain'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#three-ladies-chain"]').textContent,
+			'Three Robins chain'
+		)
+	})
+
+	it('does nothing when terms has no CHAIN_R key', () => {
+		replaceChains(new Map())
+		assert.equal(
+			document.querySelector('a[href$="#ladies-chain"]').textContent,
+			'ladies chain'
+		)
+	})
+})
+
+// ── replaceShoulderRounds ───────────────────────────────────────────────
+
+describe('replaceShoulderRounds', () => {
+	const terms = mergeTerms(RSR_TERMS)
+
+	beforeEach(() => {
+		setupDOM(`<!DOCTYPE html><html><body>
+			<span><a href="/glossary#gypsy">gypsy</a> right shoulder round</span>
+			<span><a href="/glossary#gypsy">gypsy</a> left shoulder round</span>
+		</body></html>`)
+	})
+
+	it('replaces "gypsy right" with "right shoulder round"', () => {
+		replaceShoulderRounds(terms)
+		const gypsys = document.querySelectorAll('a[href$="#gypsy"]')
+		assert.equal(gypsys[0].textContent, 'right shoulder round')
+	})
+
+	it('replaces "gypsy left" with "left shoulder round"', () => {
+		replaceShoulderRounds(terms)
+		const gypsys = document.querySelectorAll('a[href$="#gypsy"]')
+		assert.equal(gypsys[1].textContent, 'left shoulder round')
+	})
+
+	it('removes the direction word from the following text node', () => {
+		replaceShoulderRounds(terms)
+		const gypsys = document.querySelectorAll('a[href$="#gypsy"]')
+		// The text after the link should have the direction word removed
+		assert.ok(!gypsys[0].nextSibling.textContent.includes('right'))
+	})
+
+	it('does nothing when terms has no RSR key', () => {
+		replaceShoulderRounds(new Map())
+		assert.equal(
+			document.querySelector('a[href$="#gypsy"]').textContent,
+			'gypsy'
+		)
+	})
+})
+
+// ── replaceDoubleGyp ────────────────────────────────────────────────────
+
+describe('replaceDoubleGyp', () => {
+	const terms = mergeTerms(HALF_GYP_TERMS)
+
+	beforeEach(() => {
+		setupDOM(`<!DOCTYPE html><html><body>
+			<a href="/glossary#double-gyp">double gyp</a>
+		</body></html>`)
+	})
+
+	it('replaces double-gyp with quick trades', () => {
+		replaceDoubleGyp(terms)
+		assert.equal(
+			document.querySelector('a[href$="#double-gyp"]').textContent,
+			'quick trades'
+		)
+	})
+
+	it('does nothing when terms has no DOUBLE_TRADE key', () => {
+		replaceDoubleGyp(new Map())
+		assert.equal(
+			document.querySelector('a[href$="#double-gyp"]').textContent,
+			'double gyp'
+		)
+	})
+})
+
+// ── replaceMicroNotationChoreo ──────────────────────────────────────────
+
+describe('replaceMicroNotationChoreo', () => {
+	const terms = mergeTerms(ROLE_TERMS_BIRDS)
+
+	beforeEach(() => {
+		setupDOM(`<!DOCTYPE html><html><body>
+			<div id="phrases">
+				<span>MR WL M1R W2L</span>
+				<span>M roll L, W side-step R</span>
+			</div>
+		</body></html>`)
+	})
+
+	it('replaces M/W micro-notation with role initials', () => {
+		replaceMicroNotationChoreo(terms)
+		const spans = document.querySelectorAll('#phrases span')
+		assert.equal(spans[0].textContent, 'LR RL L1R R2L')
+	})
+
+	it('replaces M/W in roll and side-step notation', () => {
+		replaceMicroNotationChoreo(terms)
+		const spans = document.querySelectorAll('#phrases span')
+		assert.equal(spans[1].textContent, 'L roll L, R side-step R')
+	})
+
+	it('does nothing when terms has no MICRO_L key', () => {
+		replaceMicroNotationChoreo(new Map())
+		const spans = document.querySelectorAll('#phrases span')
+		assert.equal(spans[0].textContent, 'MR WL M1R W2L')
+	})
+
+	it('does nothing when there is no #phrases element', () => {
+		setupDOM('<!DOCTYPE html><html><body></body></html>')
+		// Should not throw
+		replaceMicroNotationChoreo(terms)
+	})
+})
+
+// ── replaceMicroNotationFormation ───────────────────────────────────────
+
+describe('replaceMicroNotationFormation', () => {
+	const terms = mergeTerms(ROLE_TERMS_BIRDS)
+
+	beforeEach(() => {
+		setupDOM(`<!DOCTYPE html><html><body>
+			<table>
+				<tr>
+					<td>FormationDetail</td>
+					<td>Wave of four (MR, WL).</td>
+				</tr>
+			</table>
+		</body></html>`)
+	})
+
+	it('replaces M/W in formation detail cell', () => {
+		replaceMicroNotationFormation(terms)
+		const cell = getFormationCell()
+		assert.equal(cell.textContent, 'Wave of four (LR, RL).')
+	})
+
+	it('does nothing when there is no formation cell', () => {
+		setupDOM('<!DOCTYPE html><html><body></body></html>')
+		// Should not throw
+		replaceMicroNotationFormation(terms)
+	})
+})
+
+// ── getDescendentTextNodes ──────────────────────────────────────────────
+
+describe('getDescendentTextNodes', () => {
+	beforeEach(() => {
+		setupDOM(`<!DOCTYPE html><html><body>
+			<div id="target">Hello <span>nested <b>deep</b></span> world</div>
+		</body></html>`)
+	})
+
+	it('returns all text nodes in an element', () => {
+		const target = document.getElementById('target')
+		const nodes = getDescendentTextNodes(target)
+		const texts = nodes.map(n => n.textContent.trim()).filter(Boolean)
+		assert.deepEqual(texts, ['Hello', 'nested', 'deep', 'world'])
+	})
+})
+
+// ── getFormationCell ────────────────────────────────────────────────────
+
+describe('getFormationCell', () => {
+	it('returns the cell after FormationDetail', () => {
+		setupDOM(`<!DOCTYPE html><html><body>
+			<table><tr>
+				<td>FormationDetail</td>
+				<td>Improper</td>
+			</tr></table>
+		</body></html>`)
+		const cell = getFormationCell()
+		assert.equal(cell.textContent, 'Improper')
+	})
+
+	it('returns undefined when no FormationDetail cell exists', () => {
+		setupDOM('<!DOCTYPE html><html><body></body></html>')
+		assert.equal(getFormationCell(), undefined)
+	})
+})
+
+// ── replaceAll (integration) ────────────────────────────────────────────
+
+describe('replaceAll', () => {
+	beforeEach(() => {
+		setupDOM(`<!DOCTYPE html><html><body>
+			<div id="phrases">
+				<a href="/glossary#men">men</a>
+				<a href="/glossary#women">women</a>
+				<a href="/glossary#ladies-chain">ladies chain</a>
+				<a href="/glossary#gypsy">gypsy</a> right
+				<a href="/glossary#double-gyp">double gyp</a>
+				<span>MR WL</span>
+			</div>
+			<table><tr>
+				<td>FormationDetail</td>
+				<td>Wave (MR, WL).</td>
+			</tr></table>
+		</body></html>`)
+	})
+
+	it('replaces all terms with birds options', () => {
+		replaceAll({ enabled: true, useRSR: true, roleTerms: 'birds' })
+		assert.equal(
+			document.querySelector('a[href$="#men"]').textContent,
+			'Larks'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#women"]').textContent,
+			'Robins'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#ladies-chain"]').textContent,
+			'Robins chain'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#gypsy"]').textContent,
+			'right shoulder round'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#double-gyp"]').textContent,
+			'quick trades'
+		)
+	})
+
+	it('replaces all terms with lead/follow options', () => {
+		replaceAll({ enabled: true, useRSR: true, roleTerms: 'lf' })
+		assert.equal(
+			document.querySelector('a[href$="#men"]').textContent,
+			'Leads'
+		)
+		assert.equal(
+			document.querySelector('a[href$="#women"]').textContent,
+			'Follows'
+		)
+	})
+
+	it('does nothing when disabled', () => {
+		replaceAll({ enabled: false, useRSR: true, roleTerms: 'birds' })
+		assert.equal(
+			document.querySelector('a[href$="#men"]').textContent,
+			'men'
+		)
+	})
+})

--- a/tests/main.test.mjs
+++ b/tests/main.test.mjs
@@ -4,7 +4,6 @@ import { setupDOM } from './setup.mjs'
 import {
 	replaceRoles,
 	replaceChains,
-	replaceShoulderRounds,
 	replaceDoubleGyp,
 	replaceMicroNotationChoreo,
 	replaceMicroNotationFormation,
@@ -14,7 +13,6 @@ import {
 	getFormationCell,
 } from '../extension/main.js'
 import {
-	RSR_TERMS,
 	HALF_GYP_TERMS,
 	ROLE_TERMS_BIRDS,
 	ROLE_TERMS_LF,
@@ -27,15 +25,13 @@ const mergeTerms = (...maps) =>
 // ── buildTerms ──────────────────────────────────────────────────────────
 
 describe('buildTerms', () => {
-	it('includes RSR and half-gyp terms when useRSR is true', () => {
+	it('includes half-gyp terms when useRSR is true', () => {
 		const terms = buildTerms({ useRSR: true, roleTerms: 'mw' })
-		assert.equal(terms.get('RSR'), 'right shoulder round')
 		assert.equal(terms.get('DOUBLE_TRADE'), 'quick trades')
 	})
 
-	it('excludes RSR terms when useRSR is false', () => {
+	it('excludes half-gyp terms when useRSR is false', () => {
 		const terms = buildTerms({ useRSR: false, roleTerms: 'mw' })
-		assert.equal(terms.has('RSR'), false)
 		assert.equal(terms.has('DOUBLE_TRADE'), false)
 	})
 
@@ -143,46 +139,6 @@ describe('replaceChains', () => {
 		assert.equal(
 			document.querySelector('a[href$="#ladies-chain"]').textContent,
 			'ladies chain'
-		)
-	})
-})
-
-// ── replaceShoulderRounds ───────────────────────────────────────────────
-
-describe('replaceShoulderRounds', () => {
-	const terms = mergeTerms(RSR_TERMS)
-
-	beforeEach(() => {
-		setupDOM(`<!DOCTYPE html><html><body>
-			<span><a href="/glossary#gypsy">gypsy</a> right shoulder round</span>
-			<span><a href="/glossary#gypsy">gypsy</a> left shoulder round</span>
-		</body></html>`)
-	})
-
-	it('replaces "gypsy right" with "right shoulder round"', () => {
-		replaceShoulderRounds(terms)
-		const gypsys = document.querySelectorAll('a[href$="#gypsy"]')
-		assert.equal(gypsys[0].textContent, 'right shoulder round')
-	})
-
-	it('replaces "gypsy left" with "left shoulder round"', () => {
-		replaceShoulderRounds(terms)
-		const gypsys = document.querySelectorAll('a[href$="#gypsy"]')
-		assert.equal(gypsys[1].textContent, 'left shoulder round')
-	})
-
-	it('removes the direction word from the following text node', () => {
-		replaceShoulderRounds(terms)
-		const gypsys = document.querySelectorAll('a[href$="#gypsy"]')
-		// The text after the link should have the direction word removed
-		assert.ok(!gypsys[0].nextSibling.textContent.includes('right'))
-	})
-
-	it('does nothing when terms has no RSR key', () => {
-		replaceShoulderRounds(new Map())
-		assert.equal(
-			document.querySelector('a[href$="#gypsy"]').textContent,
-			'gypsy'
 		)
 	})
 })
@@ -329,7 +285,6 @@ describe('replaceAll', () => {
 				<a href="/glossary#men">men</a>
 				<a href="/glossary#women">women</a>
 				<a href="/glossary#ladies-chain">ladies chain</a>
-				<a href="/glossary#gypsy">gypsy</a> right
 				<a href="/glossary#double-gyp">double gyp</a>
 				<span>MR WL</span>
 			</div>
@@ -353,10 +308,6 @@ describe('replaceAll', () => {
 		assert.equal(
 			document.querySelector('a[href$="#ladies-chain"]').textContent,
 			'Robins chain'
-		)
-		assert.equal(
-			document.querySelector('a[href$="#gypsy"]').textContent,
-			'right shoulder round'
 		)
 		assert.equal(
 			document.querySelector('a[href$="#double-gyp"]').textContent,

--- a/tests/manifest.test.mjs
+++ b/tests/manifest.test.mjs
@@ -56,6 +56,18 @@ describe('manifest.json', () => {
 		}
 	})
 
+	it('references web_accessible_resources files that exist', () => {
+		for (const entry of manifest.web_accessible_resources ?? []) {
+			for (const resource of entry.resources) {
+				const filePath = join(extDir, resource)
+				assert.ok(
+					existsSync(filePath),
+					`Web-accessible resource missing: ${resource}`
+				)
+			}
+		}
+	})
+
 	it('content script entry point does not use static import syntax', () => {
 		for (const cs of manifest.content_scripts) {
 			for (const jsFile of cs.js) {

--- a/tests/manifest.test.mjs
+++ b/tests/manifest.test.mjs
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const extDir = join(__dirname, '..', 'extension')
+const manifest = JSON.parse(readFileSync(join(extDir, 'manifest.json'), 'utf8'))
+
+describe('manifest.json', () => {
+	it('is valid JSON with required MV3 fields', () => {
+		assert.equal(manifest.manifest_version, 3)
+		assert.ok(manifest.name)
+		assert.ok(manifest.version)
+	})
+
+	it('references content script files that exist', () => {
+		for (const cs of manifest.content_scripts) {
+			for (const jsFile of cs.js) {
+				const filePath = join(extDir, jsFile)
+				assert.ok(
+					existsSync(filePath),
+					`Content script file missing: ${jsFile}`
+				)
+			}
+		}
+	})
+
+	it('references icon files that exist', () => {
+		for (const size of Object.keys(manifest.icons)) {
+			const filePath = join(extDir, manifest.icons[size])
+			assert.ok(
+				existsSync(filePath),
+				`Icon file missing: ${manifest.icons[size]}`
+			)
+		}
+	})
+
+	it('references the options page file that exists', () => {
+		const filePath = join(extDir, manifest.options_ui.page)
+		assert.ok(
+			existsSync(filePath),
+			`Options page missing: ${manifest.options_ui.page}`
+		)
+	})
+
+	it('does not use "type": "module" in content_scripts (unsupported)', () => {
+		for (const cs of manifest.content_scripts) {
+			assert.equal(
+				cs.type,
+				undefined,
+				'content_scripts "type": "module" is not supported by browsers; ' +
+				'use dynamic import() in the content script instead'
+			)
+		}
+	})
+
+	it('content script entry point does not use static import syntax', () => {
+		for (const cs of manifest.content_scripts) {
+			for (const jsFile of cs.js) {
+				const source = readFileSync(join(extDir, jsFile), 'utf8')
+				assert.ok(
+					!/^\s*import\s.+from\s/m.test(source),
+					`${jsFile} uses static import syntax, which is not supported ` +
+					'in content scripts. Use dynamic import() instead.'
+				)
+			}
+		}
+	})
+})

--- a/tests/maps.test.mjs
+++ b/tests/maps.test.mjs
@@ -1,0 +1,83 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+	RSR_TERMS,
+	HALF_GYP_TERMS,
+	ROLE_TERMS_BIRDS,
+	ROLE_TERMS_LF,
+} from '../extension/maps.js'
+
+describe('maps.js exports', () => {
+	it('exports RSR_TERMS as a Map', () => {
+		assert.ok(RSR_TERMS instanceof Map)
+	})
+
+	it('exports HALF_GYP_TERMS as a Map', () => {
+		assert.ok(HALF_GYP_TERMS instanceof Map)
+	})
+
+	it('exports ROLE_TERMS_BIRDS as a Map', () => {
+		assert.ok(ROLE_TERMS_BIRDS instanceof Map)
+	})
+
+	it('exports ROLE_TERMS_LF as a Map', () => {
+		assert.ok(ROLE_TERMS_LF instanceof Map)
+	})
+})
+
+describe('RSR_TERMS', () => {
+	it('has right shoulder round', () => {
+		assert.equal(RSR_TERMS.get('RSR'), 'right shoulder round')
+	})
+
+	it('has left shoulder round', () => {
+		assert.equal(RSR_TERMS.get('LSR'), 'left shoulder round')
+	})
+})
+
+describe('HALF_GYP_TERMS', () => {
+	it('has double trade replacement', () => {
+		assert.equal(HALF_GYP_TERMS.get('DOUBLE_TRADE'), 'quick trades')
+	})
+})
+
+describe('ROLE_TERMS_BIRDS', () => {
+	it('replaces gendered role terms with Larks/Robins', () => {
+		assert.equal(ROLE_TERMS_BIRDS.get('ROLE_R'), 'Robins')
+		assert.equal(ROLE_TERMS_BIRDS.get('ROLE_L'), 'Larks')
+	})
+
+	it('has all chain variants', () => {
+		assert.equal(ROLE_TERMS_BIRDS.get('CHAIN_R'), 'Robins chain')
+		assert.equal(ROLE_TERMS_BIRDS.get('CHAIN_L'), 'Larks chain')
+		assert.equal(ROLE_TERMS_BIRDS.get('CHAIN_R_BY_L'), 'right-hand chain')
+		assert.equal(ROLE_TERMS_BIRDS.get('GRAND_CHAIN_R'), 'Robins grand chain')
+		assert.equal(ROLE_TERMS_BIRDS.get('GRAND_CHAIN_L'), 'Larks grand chain')
+		assert.equal(ROLE_TERMS_BIRDS.get('OPEN_CHAIN_R'), 'Robins open chain')
+		assert.equal(ROLE_TERMS_BIRDS.get('OPEN_CHAIN_L'), 'Larks open chain')
+		assert.equal(ROLE_TERMS_BIRDS.get('THREE_CHAIN_R'), 'Three Robins chain')
+	})
+
+	it('has micro-notation initials', () => {
+		assert.equal(ROLE_TERMS_BIRDS.get('MICRO_R'), 'R')
+		assert.equal(ROLE_TERMS_BIRDS.get('MICRO_L'), 'L')
+	})
+})
+
+describe('ROLE_TERMS_LF', () => {
+	it('replaces gendered role terms with Leads/Follows', () => {
+		assert.equal(ROLE_TERMS_LF.get('ROLE_R'), 'Follows')
+		assert.equal(ROLE_TERMS_LF.get('ROLE_L'), 'Leads')
+	})
+
+	it('has the same keys as ROLE_TERMS_BIRDS', () => {
+		const birdsKeys = [...ROLE_TERMS_BIRDS.keys()].sort()
+		const lfKeys = [...ROLE_TERMS_LF.keys()].sort()
+		assert.deepEqual(birdsKeys, lfKeys)
+	})
+
+	it('has micro-notation initials', () => {
+		assert.equal(ROLE_TERMS_LF.get('MICRO_R'), 'F')
+		assert.equal(ROLE_TERMS_LF.get('MICRO_L'), 'L')
+	})
+})

--- a/tests/maps.test.mjs
+++ b/tests/maps.test.mjs
@@ -1,17 +1,12 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import {
-	RSR_TERMS,
 	HALF_GYP_TERMS,
 	ROLE_TERMS_BIRDS,
 	ROLE_TERMS_LF,
 } from '../extension/maps.js'
 
 describe('maps.js exports', () => {
-	it('exports RSR_TERMS as a Map', () => {
-		assert.ok(RSR_TERMS instanceof Map)
-	})
-
 	it('exports HALF_GYP_TERMS as a Map', () => {
 		assert.ok(HALF_GYP_TERMS instanceof Map)
 	})
@@ -22,16 +17,6 @@ describe('maps.js exports', () => {
 
 	it('exports ROLE_TERMS_LF as a Map', () => {
 		assert.ok(ROLE_TERMS_LF instanceof Map)
-	})
-})
-
-describe('RSR_TERMS', () => {
-	it('has right shoulder round', () => {
-		assert.equal(RSR_TERMS.get('RSR'), 'right shoulder round')
-	})
-
-	it('has left shoulder round', () => {
-		assert.equal(RSR_TERMS.get('LSR'), 'left shoulder round')
 	})
 })
 

--- a/tests/setup.mjs
+++ b/tests/setup.mjs
@@ -1,0 +1,29 @@
+// Test setup: provides a jsdom environment and mocks browser extension APIs
+// so that main.js can be imported without crashing on init().
+import { JSDOM } from 'jsdom'
+
+// Set up a minimal browser extension API mock before any extension code loads.
+// init() in main.js calls browser.storage.sync.get() at import time, so this
+// needs to be in place first.
+globalThis.chrome = {
+	storage: {
+		sync: {
+			get: async () => ({}),
+			onChanged: { addListener: () => {} },
+		},
+	},
+	runtime: {
+		getURL: (path) => path,
+	},
+}
+
+/**
+ * Create a fresh JSDOM document and install it as the global `document`.
+ * Returns the window for direct access if needed.
+ */
+export function setupDOM(html = '<!DOCTYPE html><html><body></body></html>') {
+	const dom = new JSDOM(html)
+	globalThis.document = dom.window.document
+	globalThis.NodeFilter = dom.window.NodeFilter
+	return dom.window
+}


### PR DESCRIPTION
## Summary

- **ESLint**: Add flat config (`eslint.config.mjs`) covering all `extension/` JS files with rules for common errors (`no-undef`, `prefer-const`, `eqeqeq`, etc.). `npm run lint` now runs both ESLint and `web-ext lint`.

- **ES module conversion**: Export term maps from `maps.js`; convert `main.js` to import them statically. Split the content script into a thin `content-script.js` loader (declared in the manifest) that dynamically imports `main.js` as a proper ES module — necessary because browsers don't support `"type": "module"` or static `import` in content scripts. `web_accessible_resources` added so Firefox allows the dynamic import.

- **Test suite** (`node:test` + jsdom): 41 tests across three files:
  - `maps.test.mjs` — verifies all exported `Map` constants and their contents
  - `main.test.mjs` — exercises every DOM replacement function in isolation plus a `replaceAll` integration test
  - `manifest.test.mjs` — structural validation: required fields, file existence, `web_accessible_resources` coverage of dynamically imported modules, and a check that content scripts don't use static `import` syntax (the exact bug we hit during this work)

- **CI** (`.github/workflows/ci.yml`): runs `npm run lint` and `npm test` on pushes to `main` and on all PRs.

- **Bug fixes** found during review: unhandled promise rejection in `content-script.js`; `"Three Follows chain"` capitalisation in `ROLE_TERMS_LF`.

## Test plan

- [x] `npm test` — all 41 tests pass
- [x] `npm run lint` — 0 errors (2 pre-existing `web-ext` `UNSAFE_VAR_ASSIGNMENT` warnings about `innerHTML` in `revert()`, not introduced here)
- [ ] Load extension manually in Firefox and Chrome on a Caller's Box dance page; confirm role and chain term replacements work and the popup saves/restores settings