### PR TITLE
Add plain-text role replacements for phrases and variant videos

### DIFF
--- a/extension/maps.js
+++ b/extension/maps.js
@@ -7,6 +7,9 @@ export const HALF_GYP_TERMS = new Map([
 export const ROLE_TERMS_BIRDS = new Map([
 	['ROLE_R', 'Robins'],
 	['ROLE_L', 'Larks'],
+	// Singular forms for plain-text occurrences like "man one" / "woman two"
+	['ROLE_R_S', 'Robin'],
+	['ROLE_L_S', 'Lark'],
 	['CHAIN_R', 'Robins chain'],
 	['CHAIN_L', 'Larks chain'],
 	['CHAIN_R_BY_L', 'right-hand chain'],
@@ -23,6 +26,9 @@ export const ROLE_TERMS_BIRDS = new Map([
 export const ROLE_TERMS_LF = new Map([
 	['ROLE_R', 'Follows'],
 	['ROLE_L', 'Leads'],
+	// Singular forms for plain-text occurrences like "man one" / "woman two"
+	['ROLE_R_S', 'Follow'],
+	['ROLE_L_S', 'Lead'],
 	['CHAIN_R', 'Follows chain'],
 	['CHAIN_L', 'Leads chain'],
 	['CHAIN_R_BY_L', 'right-hand chain'],

--- a/tests/maps.test.mjs
+++ b/tests/maps.test.mjs
@@ -32,6 +32,11 @@ describe('ROLE_TERMS_BIRDS', () => {
 		assert.equal(ROLE_TERMS_BIRDS.get('ROLE_L'), 'Larks')
 	})
 
+	it('has singular role terms for plain-text replacements', () => {
+		assert.equal(ROLE_TERMS_BIRDS.get('ROLE_R_S'), 'Robin')
+		assert.equal(ROLE_TERMS_BIRDS.get('ROLE_L_S'), 'Lark')
+	})
+
 	it('has all chain variants', () => {
 		assert.equal(ROLE_TERMS_BIRDS.get('CHAIN_R'), 'Robins chain')
 		assert.equal(ROLE_TERMS_BIRDS.get('CHAIN_L'), 'Larks chain')
@@ -53,6 +58,11 @@ describe('ROLE_TERMS_LF', () => {
 	it('replaces gendered role terms with Leads/Follows', () => {
 		assert.equal(ROLE_TERMS_LF.get('ROLE_R'), 'Follows')
 		assert.equal(ROLE_TERMS_LF.get('ROLE_L'), 'Leads')
+	})
+
+	it('has singular role terms for plain-text replacements', () => {
+		assert.equal(ROLE_TERMS_LF.get('ROLE_R_S'), 'Follow')
+		assert.equal(ROLE_TERMS_LF.get('ROLE_L_S'), 'Lead')
 	})
 
 	it('has the same keys as ROLE_TERMS_BIRDS', () => {


### PR DESCRIPTION
## Summary
This PR extends the role term replacement functionality to handle plain-text occurrences of gendered words (man/woman/men/women) in dance descriptions, not just glossary-linked terms. This allows dances that refer to specific dancers by name in plain text (e.g., "Man one right hand high") to be properly replaced with role-appropriate terminology.

## Key Changes
- **New term maps**: Added singular role term keys (`ROLE_L_S`, `ROLE_R_S`) to `ROLE_TERMS_BIRDS` and `ROLE_TERMS_LF` maps to support singular replacements (e.g., "man" → "Lark", "woman" → "Robin")
- **New helper function**: Created `replaceGenderedWordsInNodes()` that performs word-boundary-aware text replacements on text nodes, preventing substring matches (e.g., "promenade" is not affected)
- **New export `replaceRoleTextInPhrases()`**: Replaces gendered words in the `#phrases` element where dances describe specific dancer actions in plain text
- **New export `getVariantVideosCell()`**: Utility function to locate the VariantVideos table cell
- **New export `replaceVariantVideos()`**: Replaces gendered words in the VariantVideos field, which contains plain-text descriptions of dance variations
- **Integration**: Both new replacement functions are called in `replaceAll()` to ensure comprehensive term replacement across all content
- **Revert support**: Updated the `init()` function to preserve and restore VariantVideos cell HTML when options change
- **Comprehensive tests**: Added full test suites for all new functions with edge cases (missing elements, empty terms, substring protection)

## Implementation Details
- Uses word boundaries (`\b`) in regex patterns to avoid unintended substring replacements
- Gracefully handles missing DOM elements by returning early
- Checks for required `ROLE_L` key in terms map before processing
- Maintains consistency with existing replacement patterns and error handling

https://claude.ai/code/session_016NmUsnWfUFHmkJCHfvdinX