### PR TITLE
Safari: toggle UI, permission request flow, and match pattern fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Thumbs.db
 node_modules/
 safari/
 web-ext-artifacts/
+.env

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,6 +1,13 @@
 // Thin entry point for content scripts. Dynamically imports main.js as an
 // ES module (content scripts can't use static imports directly).
-const browser = globalThis.chrome ?? globalThis.browser
-import(browser.runtime.getURL('main.js')).catch(err =>
-	console.error(`[Caller's Box Configurator] Failed to load main.js: ${err.message}`)
-)
+try {
+	console.log('[Caller\'s Box Configurator] Content script injected')
+	const browser = globalThis.chrome ?? globalThis.browser
+	const url = browser.runtime.getURL('main.js')
+	console.log('[Caller\'s Box Configurator] Importing:', url)
+	import(url).catch(err =>
+		console.error(`[Caller's Box Configurator] Failed to load main.js: ${err.message}`)
+	)
+} catch (err) {
+	console.error(`[Caller's Box Configurator] Content script error: ${err.message}`)
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,7 +10,7 @@
 	},
 	"content_scripts": [
 		{
-			"matches": ["*://*.ibiblio.org/contradance/thecallersbox/dance.php?id=*"],
+			"matches": ["*://*.ibiblio.org/contradance/thecallersbox/*"],
 			"js": ["content-script.js"],
 			"run_at": "document_end"
 		}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -38,5 +38,6 @@
 			"matches": ["*://*.ibiblio.org/*"]
 		}
 	],
-	"permissions": ["storage"]
+	"permissions": ["storage"],
+	"optional_host_permissions": ["*://*.ibiblio.org/*"]
 }

--- a/extension/options.html
+++ b/extension/options.html
@@ -15,6 +15,9 @@
 			margin: 0;
 			padding: 0;
 		}
+		.container {
+			min-width: 300px;
+		}
 		h1 {
 			font-size: inherit;
 			font-weight: bold;
@@ -30,11 +33,12 @@
 				border-color: rgba(255,255,255,0.25)
 			}
 		}
-		/* Toggle switches */
+		/* Toggle switches — label on left, toggle on right (macOS style) */
 		.form-row label:has(input[type="checkbox"]) {
 			display: flex;
 			align-items: center;
-			gap: 0.75ch;
+			justify-content: space-between;
+			gap: 1ch;
 			cursor: pointer;
 		}
 		input[type="checkbox"] {
@@ -51,6 +55,7 @@
 			position: relative;
 			transition: background 0.25s ease;
 			flex-shrink: 0;
+			order: 1;
 		}
 		.toggle-track::before {
 			content: "";
@@ -73,6 +78,20 @@
 		input[type="checkbox"]:focus-visible + .toggle-track {
 			outline: 2px solid -webkit-focus-ring-color;
 			outline-offset: 2px;
+		}
+		/* Select row */
+		.form-row:has(select) {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 1ch;
+		}
+		/* Disabled state — dim options when extension is off */
+		.form-row:has(:disabled) {
+			opacity: 0.4;
+		}
+		.form-row:has(:disabled) label {
+			cursor: default;
 		}
 		/* Permissions banner */
 		#permissions-banner p {

--- a/extension/options.html
+++ b/extension/options.html
@@ -30,11 +30,21 @@
 				border-color: rgba(255,255,255,0.25)
 			}
 		}
+		#permissions-banner p {
+			margin: 0 0 0.5em;
+		}
+		#permissions-banner button {
+			cursor: pointer;
+		}
 	</style>
 </head>
 <body>
 	<div class="container">
 		<h1>Caller's Box Configurator</h1>
+		<section class="form-row" id="permissions-banner" hidden>
+			<p>This extension needs access to the Caller's Box website to work.</p>
+			<button id="grant-access">Grant Website Access</button>
+		</section>
 		<cb-options-form>
 			<form>
 				<section class="form-row">

--- a/extension/options.html
+++ b/extension/options.html
@@ -30,11 +30,68 @@
 				border-color: rgba(255,255,255,0.25)
 			}
 		}
+		/* Toggle switches */
+		.form-row label:has(input[type="checkbox"]) {
+			display: flex;
+			align-items: center;
+			gap: 0.75ch;
+			cursor: pointer;
+		}
+		input[type="checkbox"] {
+			position: absolute;
+			opacity: 0;
+			pointer-events: none;
+		}
+		.toggle-track {
+			display: inline-block;
+			width: 34px;
+			height: 20px;
+			background: rgba(120, 120, 128, 0.32);
+			border-radius: 11px;
+			position: relative;
+			transition: background 0.25s ease;
+			flex-shrink: 0;
+		}
+		.toggle-track::before {
+			content: "";
+			position: absolute;
+			width: 16px;
+			height: 16px;
+			border-radius: 50%;
+			background: white;
+			top: 2px;
+			left: 2px;
+			transition: transform 0.25s ease;
+			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+		}
+		input[type="checkbox"]:checked + .toggle-track {
+			background: #34c759;
+		}
+		input[type="checkbox"]:checked + .toggle-track::before {
+			transform: translateX(14px);
+		}
+		input[type="checkbox"]:focus-visible + .toggle-track {
+			outline: 2px solid -webkit-focus-ring-color;
+			outline-offset: 2px;
+		}
+		/* Permissions banner */
 		#permissions-banner p {
 			margin: 0 0 0.5em;
 		}
 		#permissions-banner button {
 			cursor: pointer;
+			-webkit-appearance: none;
+			appearance: none;
+			background: #007aff;
+			color: white;
+			border: none;
+			border-radius: 6px;
+			padding: 0.4em 1em;
+			font-size: inherit;
+			font-family: inherit;
+		}
+		#permissions-banner button:active {
+			opacity: 0.7;
 		}
 	</style>
 </head>
@@ -49,13 +106,17 @@
 			<form>
 				<section class="form-row">
 					<label>
-						<input type="checkbox" name="enabled"> Enabled
+						<input type="checkbox" name="enabled">
+						<span class="toggle-track"></span>
+						Enabled
 					</label>
 				</section>
 
 				<section class="form-row">
 					<label title="Replace “double gyp” with “quick trades”">
-						<input type="checkbox" name="useRSR"> Replace “double gyp” with “quick trades”
+						<input type="checkbox" name="useRSR">
+						<span class="toggle-track"></span>
+						Replace “double gyp” with “quick trades”
 					</label>
 				</section>
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -41,21 +41,27 @@ customElements.define('cb-options-form', OptionsForm)
 
 // Permission check — Safari (and some MV3 browsers) require explicit user
 // grants for content script host access. Show a banner when not yet granted.
-const REQUIRED_ORIGINS = ['*://*.ibiblio.org/*']
+//
+// Check the exact pattern from content_scripts.matches so that Chrome (which
+// implicitly grants it) returns true and avoids showing the banner needlessly.
+// Request the broader pattern declared in optional_host_permissions.
+const CONTENT_SCRIPT_ORIGINS = ['*://*.ibiblio.org/contradance/thecallersbox/dance.php?id=*']
+const REQUEST_ORIGINS = ['*://*.ibiblio.org/*']
 const permissionsBanner = document.getElementById('permissions-banner')
 const grantAccessBtn = document.getElementById('grant-access')
 
 if (permissionsBanner && grantAccessBtn) {
-	browser.permissions.contains({ origins: REQUIRED_ORIGINS })
+	browser.permissions.contains({ origins: CONTENT_SCRIPT_ORIGINS })
 		.then(granted => { permissionsBanner.hidden = granted })
 		.catch(() => { permissionsBanner.hidden = true })
 
 	// Call permissions.request() synchronously in the click handler —
 	// an async gap before this call would lose the user-gesture context.
 	grantAccessBtn.addEventListener('click', () => {
-		browser.permissions.request({ origins: REQUIRED_ORIGINS })
+		browser.permissions.request({ origins: REQUEST_ORIGINS })
 			.then(granted => {
 				if (granted) permissionsBanner.hidden = true
 			})
+			.catch(() => {})
 	})
 }

--- a/extension/options.js
+++ b/extension/options.js
@@ -45,7 +45,7 @@ customElements.define('cb-options-form', OptionsForm)
 // Check the exact pattern from content_scripts.matches so that Chrome (which
 // implicitly grants it) returns true and avoids showing the banner needlessly.
 // Request the broader pattern declared in optional_host_permissions.
-const CONTENT_SCRIPT_ORIGINS = ['*://*.ibiblio.org/contradance/thecallersbox/dance.php?id=*']
+const CONTENT_SCRIPT_ORIGINS = ['*://*.ibiblio.org/contradance/thecallersbox/*']
 const REQUEST_ORIGINS = ['*://*.ibiblio.org/*']
 const permissionsBanner = document.getElementById('permissions-banner')
 const grantAccessBtn = document.getElementById('grant-access')

--- a/extension/options.js
+++ b/extension/options.js
@@ -10,7 +10,10 @@ class OptionsForm extends HTMLElement {
 	connectedCallback() {
 		this.form = this.querySelector('form')
 		this.restoreOptions()
-		this.form.addEventListener('input', this.saveOptions.bind(this))
+		this.form.addEventListener('input', () => {
+			this.saveOptions()
+			this.updateEnabledState()
+		})
 	}
 
 	async restoreOptions() {
@@ -25,6 +28,13 @@ class OptionsForm extends HTMLElement {
 				el.value = value
 			}
 		})
+		this.updateEnabledState()
+	}
+
+	updateEnabledState() {
+		const enabled = this.form.querySelector('[name=enabled]').checked
+		this.form.querySelector('[name=useRSR]').disabled = !enabled
+		this.form.querySelector('[name=roleTerms]').disabled = !enabled
 	}
 
 	async saveOptions() {

--- a/extension/options.js
+++ b/extension/options.js
@@ -38,3 +38,24 @@ class OptionsForm extends HTMLElement {
 }
 
 customElements.define('cb-options-form', OptionsForm)
+
+// Permission check — Safari (and some MV3 browsers) require explicit user
+// grants for content script host access. Show a banner when not yet granted.
+const REQUIRED_ORIGINS = ['*://*.ibiblio.org/*']
+const permissionsBanner = document.getElementById('permissions-banner')
+const grantAccessBtn = document.getElementById('grant-access')
+
+if (permissionsBanner && grantAccessBtn) {
+	browser.permissions.contains({ origins: REQUIRED_ORIGINS })
+		.then(granted => { permissionsBanner.hidden = granted })
+		.catch(() => { permissionsBanner.hidden = true })
+
+	// Call permissions.request() synchronously in the click handler —
+	// an async gap before this call would lose the user-gesture context.
+	grantAccessBtn.addEventListener('click', () => {
+		browser.permissions.request({ origins: REQUIRED_ORIGINS })
+			.then(granted => {
+				if (granted) permissionsBanner.hidden = true
+			})
+	})
+}

--- a/extension/options.js
+++ b/extension/options.js
@@ -60,7 +60,18 @@ if (permissionsBanner && grantAccessBtn) {
 	grantAccessBtn.addEventListener('click', () => {
 		browser.permissions.request({ origins: REQUEST_ORIGINS })
 			.then(granted => {
-				if (granted) permissionsBanner.hidden = true
+				if (granted) {
+					permissionsBanner.hidden = true
+					// Reload the active tab so the content script runs
+					// on the already-loaded page.
+					if (browser.tabs) {
+						browser.tabs.query({ active: true, currentWindow: true })
+							.then(tabs => {
+								if (tabs[0]) browser.tabs.reload(tabs[0].id)
+							})
+							.catch(() => {})
+					}
+				}
 			})
 			.catch(() => {})
 	})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"start": "web-ext run -s extension/",
 		"build": "web-ext build -s extension/",
-		"build:safari": "xcrun safari-web-extension-packager extension/ --project-location safari/ --app-name \"Caller's Box Configurator\" --bundle-identifier com.chromamine.callersboxconfigurator --swift --no-open --no-prompt --force",
+		"build:safari": "xcrun safari-web-extension-packager extension/ --project-location safari/ --app-name \"Caller's Box Configurator\" --bundle-identifier com.chromamine.callersboxconfigurator --swift --no-open --no-prompt --force && find safari/ -type f \\( -name '*.swift' -o -name '*.html' -o -name '*.plist' -o -name '*.storyboard' -o -name '*.xib' -o -name '*.strings' \\) -exec sed -i '' \"s/&apos;/'/g\" {} +",
 		"lint": "eslint extension/ && web-ext lint -s extension/",
 		"lint:js": "eslint extension/",
 		"lint:ext": "web-ext lint -s extension/",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"start": "web-ext run -s extension/",
 		"build": "web-ext build -s extension/",
-		"build:safari": "xcrun safari-web-extension-packager extension/ --project-location safari/ --app-name \"Caller's Box Configurator\" --bundle-identifier com.chromamine.callersboxconfigurator --swift --no-open --no-prompt --force && find safari/ -type f \\( -name '*.swift' -o -name '*.html' -o -name '*.plist' -o -name '*.storyboard' -o -name '*.xib' -o -name '*.strings' \\) -exec sed -i '' \"s/&apos;/'/g\" {} +",
+		"build:safari": "bash scripts/build-safari.sh",
 		"lint": "eslint extension/ && web-ext lint -s extension/",
 		"lint:js": "eslint extension/",
 		"lint:ext": "web-ext lint -s extension/",

--- a/scripts/build-safari.sh
+++ b/scripts/build-safari.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Load signing config from .env if present
+if [ -f .env ]; then
+	# shellcheck source=/dev/null
+	. ./.env
+fi
+
+PROJ_DIR="safari/Caller's Box Configurator"
+PBXPROJ="$PROJ_DIR/Caller's Box Configurator.xcodeproj/project.pbxproj"
+
+# Generate the Xcode project from extension/ sources
+xcrun safari-web-extension-packager extension/ \
+	--project-location safari/ \
+	--app-name "Caller's Box Configurator" \
+	--bundle-identifier com.chromamine.callersboxconfigurator \
+	--swift --no-open --no-prompt --force
+
+# Fix HTML entity escaping introduced by the packager
+find safari/ -type f \( \
+	-name '*.swift' -o -name '*.html' -o -name '*.plist' \
+	-o -name '*.storyboard' -o -name '*.xib' -o -name '*.strings' \
+\) -exec sed -i '' "s/&apos;/'/g" {} +
+
+# Patch in signing team if configured
+if [ -n "${DEVELOPMENT_TEAM:-}" ]; then
+	sed -i '' "s/CODE_SIGN_STYLE = Automatic;/CODE_SIGN_STYLE = Automatic; DEVELOPMENT_TEAM = $DEVELOPMENT_TEAM;/g" "$PBXPROJ"
+	echo "Set DEVELOPMENT_TEAM=$DEVELOPMENT_TEAM in Xcode project"
+else
+	echo "No DEVELOPMENT_TEAM set — Xcode will default to no team (see .env)"
+fi

--- a/scripts/build-safari.sh
+++ b/scripts/build-safari.sh
@@ -21,7 +21,8 @@ xcrun safari-web-extension-packager extension/ \
 # Search all text files (skipping binaries via grep -I) rather than
 # hard-coding extensions, so we catch .pbxproj, .xcstrings, etc.
 find safari/ -type f -exec grep -lI '&apos;' {} + 2>/dev/null \
-	| while IFS= read -r f; do sed -i '' "s/&apos;/'/g" "$f"; done
+	| while IFS= read -r f; do sed -i '' "s/&apos;/'/g" "$f"; done \
+	|| true
 
 # Patch in signing team if configured
 if [ -n "${DEVELOPMENT_TEAM:-}" ]; then

--- a/scripts/build-safari.sh
+++ b/scripts/build-safari.sh
@@ -17,15 +17,12 @@ xcrun safari-web-extension-packager extension/ \
 	--bundle-identifier com.chromamine.callersboxconfigurator \
 	--swift --no-open --no-prompt --force
 
-# Fix &apos; entity escaping the packager introduces into Xcode project
-# metadata when the app name contains an apostrophe.  Target only project
-# files where the entity is wrong — leave extension source (HTML/JS/CSS)
-# untouched so legitimate entities aren't corrupted.
-find safari/ -type f \
-	\( -name '*.pbxproj' -o -name '*.plist' -o -name '*.xcstrings' -o -name '*.swift' \) \
-	-exec grep -l '&apos;' {} + 2>/dev/null \
-	| while IFS= read -r f; do sed -i '' "s/&apos;/'/g" "$f"; done \
-	|| true
+# The packager escapes the apostrophe in "Caller's Box Configurator" as
+# &apos; inside JS string literals assigned to .innerText in Script.js.
+# The browser renders the raw entity characters on screen instead of an
+# apostrophe, so fix it up.
+SCRIPT_JS="$PROJ_DIR/Shared (App)/Resources/Script.js"
+sed -i '' "s/&apos;/'/g" "$SCRIPT_JS"
 
 # Patch in signing team if configured
 if [ -n "${DEVELOPMENT_TEAM:-}" ]; then

--- a/scripts/build-safari.sh
+++ b/scripts/build-safari.sh
@@ -17,11 +17,11 @@ xcrun safari-web-extension-packager extension/ \
 	--bundle-identifier com.chromamine.callersboxconfigurator \
 	--swift --no-open --no-prompt --force
 
-# Fix HTML entity escaping introduced by the packager
-find safari/ -type f \( \
-	-name '*.swift' -o -name '*.html' -o -name '*.plist' \
-	-o -name '*.storyboard' -o -name '*.xib' -o -name '*.strings' \
-\) -exec sed -i '' "s/&apos;/'/g" {} +
+# Fix HTML entity escaping introduced by the packager.
+# Search all text files (skipping binaries via grep -I) rather than
+# hard-coding extensions, so we catch .pbxproj, .xcstrings, etc.
+find safari/ -type f -exec grep -lI '&apos;' {} + 2>/dev/null \
+	| while IFS= read -r f; do sed -i '' "s/&apos;/'/g" "$f"; done
 
 # Patch in signing team if configured
 if [ -n "${DEVELOPMENT_TEAM:-}" ]; then

--- a/scripts/build-safari.sh
+++ b/scripts/build-safari.sh
@@ -17,10 +17,13 @@ xcrun safari-web-extension-packager extension/ \
 	--bundle-identifier com.chromamine.callersboxconfigurator \
 	--swift --no-open --no-prompt --force
 
-# Fix HTML entity escaping introduced by the packager.
-# Search all text files (skipping binaries via grep -I) rather than
-# hard-coding extensions, so we catch .pbxproj, .xcstrings, etc.
-find safari/ -type f -exec grep -lI '&apos;' {} + 2>/dev/null \
+# Fix &apos; entity escaping the packager introduces into Xcode project
+# metadata when the app name contains an apostrophe.  Target only project
+# files where the entity is wrong — leave extension source (HTML/JS/CSS)
+# untouched so legitimate entities aren't corrupted.
+find safari/ -type f \
+	\( -name '*.pbxproj' -o -name '*.plist' -o -name '*.xcstrings' -o -name '*.swift' \) \
+	-exec grep -l '&apos;' {} + 2>/dev/null \
 	| while IFS= read -r f; do sed -i '' "s/&apos;/'/g" "$f"; done \
 	|| true
 


### PR DESCRIPTION
## Summary

- Restyle checkboxes as iOS/macOS-style toggle switches (pill-shaped, green when on)
- Add right-aligned toggle layout and disabled state for dependent options when extension is off
- Add a "Grant Website Access" banner in the popup for Safari, which requests `optional_host_permissions` and reloads the active tab after grant
- Broaden content script match pattern from `dance.php?id=*` to `thecallersbox/*` — Safari doesn't support query-string matching in MV3 `matches` patterns, so the content script never ran
- Add diagnostic logging to `content-script.js` for Safari debugging
- Extract Safari build into `scripts/build-safari.sh` with auto-signing support via `.env`

## Test plan

- [ ] Load extension in Chrome — toggles render correctly, options save/restore, disabled state works when "Enabled" is off
- [ ] Load extension in Firefox — same as above
- [ ] Load in Safari (macOS or iOS) — permission banner appears on first open, "Grant Website Access" grants access and reloads the tab, content script runs on dance pages
- [ ] Verify content script fires on `dance.php?id=*` URLs in all three browsers
- [ ] Verify `npm test` passes
- [ ] Verify `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)